### PR TITLE
Fix for IA64, increased PTHREAD_STACK_REQUIRED to 196608

### DIFF
--- a/client/pps-client.cpp
+++ b/client/pps-client.cpp
@@ -1013,9 +1013,7 @@ int makeTimeCorrection(struct timeval pps_t){
 
 	g.isControlling = getAcquireState();				// Provides enough time to reduce time slew on startup.
 	if (g.isControlling){
-		
-		sprintf(g.logbuf, "isControlling: true\n");
-		
+				
 		g.avgCorrection = getMovingAverage(g.timeCorrection);
 
 		makeAverageIntegral(g.avgCorrection);			// Constructs an average of integrals of one
@@ -1035,7 +1033,6 @@ int makeTimeCorrection(struct timeval pps_t){
 		g.activeCount += 1;
 	}
 	else {
-		sprintf(g.logbuf, "isControlling: false\n");
 		g.t_count = g.t_now;							// Unless g.isControlling let g.t_count copy pps_t.tv_sec.
 	}													// If g.isControlling then g.t_count is an independent counter.
 
@@ -1319,14 +1316,12 @@ void waitForPPS(bool verbose, pps_handle_t *pps_handle, int *pps_mode){
 
 			rv = loadLastState();		// Attempts to use the previous state to avoid long restarts.
 			if (rv == -1){				// If the previous state is from a recent state can save restart time.
-				printf("Breaking from loadLastState()\n");
 				break;
 			}
 			readState = true;
 		}
 
 		if (g.startingFromRestore > 0){		// Only used on restore
-			printf("Starting from restore\n");
 			g.startingFromRestore -= 1;		// Stops decrementing when g.startingFromRestore == 0
 
 			g.t_now = getNearestSecond();
@@ -1346,10 +1341,7 @@ void waitForPPS(bool verbose, pps_handle_t *pps_handle, int *pps_mode){
 
 		nanosleep(&ts2, NULL);			// Sleep until ready to look for PPS interrupt
 
-		restart = readPPS_SetTime(verbose, &tcp, pps_handle, pps_mode);
-		
-		sprintf(g.logbuf, "Result from restart: %i\n", restart);
-		
+		restart = readPPS_SetTime(verbose, &tcp, pps_handle, pps_mode);		
 		if (restart == -1){
 			break;
 		}
@@ -1388,7 +1380,6 @@ void waitForPPS(bool verbose, pps_handle_t *pps_handle, int *pps_mode){
 			writeStatusStrings();
 
 			if (! g.interruptLost && ! g.isDelaySpike){
-				sprintf(g.logbuf, "No interrupt loss and no delay spike.\n");
 				if (getConfigs() == -1){
 					break;
 				}

--- a/client/pps-client.cpp
+++ b/client/pps-client.cpp
@@ -50,7 +50,7 @@ extern int adjtimex (struct timex *timex);
  */
 //extern int gettimeofday(struct timeval *tv, struct timezone *tz);
 
-const char *version = "2.0.4";							//!< Program v2.0.3 updated on 11 Jan 2021
+const char *version = "2.0.5";							//!< Program v2.0.3 updated on 11 Jan 2021
 
 struct G g;												//!< Declares the global variables defined in pps-client.h.
 
@@ -1013,7 +1013,9 @@ int makeTimeCorrection(struct timeval pps_t){
 
 	g.isControlling = getAcquireState();				// Provides enough time to reduce time slew on startup.
 	if (g.isControlling){
-
+		
+		sprintf(g.logbuf, "isControlling: true\n");
+		
 		g.avgCorrection = getMovingAverage(g.timeCorrection);
 
 		makeAverageIntegral(g.avgCorrection);			// Constructs an average of integrals of one
@@ -1033,6 +1035,7 @@ int makeTimeCorrection(struct timeval pps_t){
 		g.activeCount += 1;
 	}
 	else {
+		sprintf(g.logbuf, "isControlling: false\n");
 		g.t_count = g.t_now;							// Unless g.isControlling let g.t_count copy pps_t.tv_sec.
 	}													// If g.isControlling then g.t_count is an independent counter.
 
@@ -1090,7 +1093,7 @@ int checkPPSInterrupt(void){
  * @returns The length of time to sleep in seconds and nanoseconds.
  */
 struct timespec setSyncDelay(int timeAt, int fracSec){
-
+	
 	struct timespec ts2;
 
 	int timerVal = USECS_PER_SEC - fracSec + timeAt;
@@ -1139,7 +1142,7 @@ struct timespec setSyncDelay(int timeAt, int fracSec){
  */
 int readPPS_SetTime(bool verbose, timeCheckParams *tcp, pps_handle_t *pps_handle, int *pps_mode){
 	int restart = 0;
-
+	
 	int rv = readPPSTimestamp(pps_handle, pps_mode, g.tm);
 
 	detectMissedPPS();
@@ -1260,6 +1263,7 @@ void waitForPPS(bool verbose, pps_handle_t *pps_handle, int *pps_mode){
 	int rv;
 	timeCheckParams tcp;
 	int restart = 0;
+	char buf[500];
 
 	if (g.doNISTsettime){
 		rv = allocInitializeNISTThreads(&tcp);
@@ -1292,19 +1296,37 @@ void waitForPPS(bool verbose, pps_handle_t *pps_handle, int *pps_mode){
 	timePPS = -PPS_WINDOW;		    	// continuously re-timing to before the roll-over of the second.
 										// timePPS allows for a time window in which to look for the PPS
 	writeStatusStrings();
+		
+	if (g.checkNTP) {
+		printf("Startup NTP check enabled, checking %s\n", g.ntpServer);
 
+		char *cmd = buf;								// Construct a command string:
+
+		sprintf(cmd, "ntpdate %s", g.ntpServer);
+	
+		printf("Running %s\n", cmd);
+
+		int rv = sysCommand(cmd);						// Issue the command:
+		if (rv == -1){
+			printf("Error running NTP check: %d\n", errno);
+		}
+	
+	}
+	
 	for (;;){							// Look for the PPS time returned by the PPS driver
 
 		if (readState == false){
 
 			rv = loadLastState();		// Attempts to use the previous state to avoid long restarts.
 			if (rv == -1){				// If the previous state is from a recent state can save restart time.
+				printf("Breaking from loadLastState()\n");
 				break;
 			}
 			readState = true;
 		}
 
 		if (g.startingFromRestore > 0){		// Only used on restore
+			printf("Starting from restore\n");
 			g.startingFromRestore -= 1;		// Stops decrementing when g.startingFromRestore == 0
 
 			g.t_now = getNearestSecond();
@@ -1325,6 +1347,9 @@ void waitForPPS(bool verbose, pps_handle_t *pps_handle, int *pps_mode){
 		nanosleep(&ts2, NULL);			// Sleep until ready to look for PPS interrupt
 
 		restart = readPPS_SetTime(verbose, &tcp, pps_handle, pps_mode);
+		
+		sprintf(g.logbuf, "Result from restart: %i\n", restart);
+		
 		if (restart == -1){
 			break;
 		}
@@ -1363,17 +1388,19 @@ void waitForPPS(bool verbose, pps_handle_t *pps_handle, int *pps_mode){
 			writeStatusStrings();
 
 			if (! g.interruptLost && ! g.isDelaySpike){
+				sprintf(g.logbuf, "No interrupt loss and no delay spike.\n");
 				if (getConfigs() == -1){
 					break;
 				}
 			}
 		}
 
-//		if (verbose){
-//			printDuration(&tv1, &tst);
-//		}
-	}
+		//if (verbose){
+		//	printDuration(&tv1, &tst);
+		//}
 
+	}
+		
 	saveLastState();
 
 end:
@@ -1415,7 +1442,9 @@ int main(int argc, char *argv[])
 	int rv = 0;
 	int ppid;
 	bool verbose = false;
-
+	
+	setlinebuf(stdout);
+	
 	if (argc > 1){
 		if (strcmp(argv[1], "-v") == 0){
 			verbose = true;

--- a/client/pps-client.h
+++ b/client/pps-client.h
@@ -137,7 +137,8 @@
 #define PPSPHASE 2097152
 #define PROCDIR 4194304
 #define SEGREGATE 8388608
-
+#define NTPCHECK 16777216
+#define NTPSERVER 33554432
 
 /*
  * Struct for passing arguments to and from threads
@@ -242,7 +243,10 @@ struct G {
 	bool doSerialsettime;
 	bool serialTimeUpdated;
 	int serialTimeError;							//!< Error reported by GPS serial port.S
-
+	
+	bool checkNTP;									//!< Enable checking NTP at startup
+	char ntpServer[40];								//!< NTP server to use for checking
+	
 	char linuxVersion[20];							//!< Array for recording the Linux version.
 	/**
 	 * @cond FILES

--- a/client/pps-client.h
+++ b/client/pps-client.h
@@ -59,7 +59,7 @@
 #define INTEGRAL_GAIN 0.63212				//!< Controller integral gain constant in active controller operation
 #define FREQDIFF_INTRVL 5					//!< The number of minutes between Allan deviation samples of system clock frequency correction
 #define PPS_WINDOW 500						//!< WaitForPPS delay loop time window in which to look for a PPS
-#define PTHREAD_STACK_REQUIRED 16384		//!< Stack space requirements for threads
+#define PTHREAD_STACK_REQUIRED 196608		//!< Stack space requirements for threads
 
 #define ZERO_OFFSET_RPI3 7
 #define ZERO_OFFSET_RPI4 4

--- a/client/pps-client.h
+++ b/client/pps-client.h
@@ -246,6 +246,7 @@ struct G {
 	
 	bool checkNTP;									//!< Enable checking NTP at startup
 	char ntpServer[40];								//!< NTP server to use for checking
+	bool ntpChecked;								//!< Flag set when we have done a first NTP adjustment
 	
 	char linuxVersion[20];							//!< Array for recording the Linux version.
 	/**
@@ -414,6 +415,7 @@ public:
 };
 
 int sysCommand(const char *);
+int checkNTP(const char *);
 void initSerialLocalData(void);
 void bufferStatusMsg(const char *);
 int writeStatusStrings(void);

--- a/client/pps-files.cpp
+++ b/client/pps-files.cpp
@@ -24,7 +24,7 @@
 
 extern struct G g;
 
-const char *config_file = "/XXXX/pps-client.conf";								//!< The PPS-Client configuration file.
+const char *config_file = "/etc/pps-client.conf";								//!< The PPS-Client configuration file.
 const char *last_distrib_file = "/pps-error-distrib";							//!< Stores the completed distribution of offset corrections.
 const char *distrib_file = "/pps-error-distrib-forming";						//!< Stores a forming distribution of offset corrections.
 const char *last_jitter_distrib_file = "/pps-jitter-distrib";					//!< Stores the completed distribution of offset corrections.
@@ -95,7 +95,9 @@ const char *valid_config[] = {
 		"ppsdevice",
 		"ppsphase",
 		"procdir",
-		"segregate"
+		"segregate",
+		"ntpcheck",
+		"ntpServer"
 };
 
 /**
@@ -252,7 +254,7 @@ char *getString(int key){
  */
 bool hasString(int key, const char *string){
 	int i = round(log2(key));
-
+	
 	if (g.config_select & key){
 		char *val = strstr(g.configVals[i], string);
 		if (val != NULL){
@@ -1346,6 +1348,18 @@ int getSharedConfigs(void){
 		g.doNISTsettime = false;
 	}
 
+	if (isEnabled(NTPCHECK)){
+		g.checkNTP = true;
+	}
+	else if (isDisabled(NTPCHECK)){
+		g.checkNTP = false;
+	}
+
+	sp = getString(NTPSERVER);
+	if (sp != NULL){
+		strcpy(g.ntpServer, sp);
+	}
+		
 	return 0;
 }
 
@@ -1569,6 +1583,18 @@ int getConfigs(void){
 		g.exitOnLostPPS = false;
 	}
 
+	if (isEnabled(NTPCHECK)){
+		g.checkNTP = true;
+	}
+	else if (isDisabled(NTPCHECK)){
+		g.checkNTP = false;
+	}
+
+	sp = getString(NTPSERVER);
+	if (sp != NULL){
+		strcpy(g.ntpServer, sp);
+	}
+	
 	return 0;
 }
 

--- a/pps-client.conf
+++ b/pps-client.conf
@@ -41,15 +41,6 @@ ppsdevice=/dev/pps0
 # used instead of the default values.
 #zeroOffset=0
 
-# In very noisy process environments or for testing it may be desirable to segregate 
-# PPS-Client from other processes running on the processor (with a reduction of one core 
-# for the other processes). This can be done by specifying which core PPS-Client should  
-# run on and the number of cores (or threads on Intel/AMD processors) on the processor. 
-# The default is no segregation and all cores are used for all process. Cores are numbered 
-# from 0 to n-1 where n is the number of cores. For a small processor like Raspberry Pi, 
-# to have PPS-Client run on core 0 of 4 cores this would be specified (uncommented) as,
-#segregate=0/4
-
 # In most cases the PPS input is a normally low pulse that goes to a high logic level 
 # for a small percentage of the time. However, if the PPS is introduced through a serial 
 # port, the interface hardware might invert the phase so that the resulting RS232 pulse 
@@ -96,3 +87,19 @@ builddir=/lib/modules/$(shell uname -r)/build
 
 # Directory for virtual file system and running processes
 procdir=/proc
+
+# In very noisy process environments or for testing it may be desirable to segregate 
+# PPS-Client from other processes running on the processor (with a reduction of one core 
+# for the other processes). This can be done by specifying which core PPS-Client should  
+# run on and the number of cores (or threads on Intel/AMD processors) on the processor. 
+# The default is no segregation and all cores are used for all process. Cores are numbered 
+# from 0 to n-1 where n is the number of cores. For a small processor like Raspberry Pi, 
+# to have PPS-Client run on core 0 of 4 cores this would be specified (uncommented) as,
+#segregate=0/4
+
+# Enable checking NTP server on first run
+ntpcheck=enable
+
+# Set the server to use for the first ntpdate update, which is fallback for when PPS has
+# not been detected
+ntpServer=0.es.pool.ntp.org


### PR DESCRIPTION
On a Raspberry Pi 4, running Ubuntu 20.04, the pthread allocation failed, as the size was below the minimum defined for the architecture. Refer to last comment of https://bugzilla.redhat.com/show_bug.cgi?id=111920 

With the increased size definition, the client runs, it would previously fail as reported in issue https://github.com/rascol/PPS-Client/issues/4#issue-1121083936